### PR TITLE
fixed comment

### DIFF
--- a/public/partials/templates/myaccount/mwb-show-subscription-details.php
+++ b/public/partials/templates/myaccount/mwb-show-subscription-details.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * The add new payment.
+ * Subscription detail page
  *
  * @link       https://wpswing.com/
  * @since      1.0.0


### PR DESCRIPTION
The template's comment was confusing and probably copied incorrectly from https://github.com/wpswings/subscriptions-for-woocommerce/blob/master/public/partials/templates/myaccount/mwb-add-new-payment-details.php
Update mwb-show-subscription-details.php