### PR TITLE
Fix renewal orders that do not need processing are not transitioned to completed such as virtual downloadable products

### DIFF
--- a/package/gateways/paypal/class-wps-subscriptions-payment-paypal-main.php
+++ b/package/gateways/paypal/class-wps-subscriptions-payment-paypal-main.php
@@ -275,10 +275,10 @@ if ( ! class_exists( 'Wps_Subscriptions_Payment_Paypal_Main' ) ) {
 
 				$wps_sfw_renewal_order = wps_sfw_get_meta_data( $order_id, 'wps_sfw_renewal_order', true );
 				if ( 'paypal' == $payment_method && 'yes' == $wps_sfw_renewal_order ) {
-					$order_status[] = 'wps_renewal';
+					$order_status[] = 'wc-wps_renewal';
 				}
 				if ( 'ppec_paypal' == $payment_method && 'yes' == $wps_sfw_renewal_order ) {
-					$order_status[] = 'wps_renewal';
+					$order_status[] = 'wc-wps_renewal';
 				}
 			}
 			return $order_status;

--- a/package/gateways/stripe/class-wps-subscriptions-payment-stripe-main.php
+++ b/package/gateways/stripe/class-wps-subscriptions-payment-stripe-main.php
@@ -55,7 +55,7 @@ if ( ! class_exists( 'Wps_Subscriptions_Payment_Stripe_Main' ) ) {
 
 				$wps_sfw_renewal_order = wps_sfw_get_meta_data( $order_id, 'wps_sfw_renewal_order', true );
 				if ( in_array( $payment_method, $allmethod ) && 'yes' == $wps_sfw_renewal_order ) {
-					$order_status[] = 'wps_renewal';
+					$order_status[] = 'wc-wps_renewal';
 
 				}
 			}

--- a/package/gateways/woocybs/class-wps-subscriptions-payment-woocybs-main.php
+++ b/package/gateways/woocybs/class-wps-subscriptions-payment-woocybs-main.php
@@ -248,7 +248,7 @@ if ( ! class_exists( 'Wps_Subscriptions_Payment_Woocybs_Main' ) ) {
 
 				$wps_sfw_renewal_order = wps_sfw_get_meta_data( $order_id, 'wps_sfw_renewal_order', true );
 				if ( $this->wps_wsp_check_supported_payment_options( $payment_method ) && 'yes' == $wps_sfw_renewal_order ) {
-					$order_status[] = 'wps_renewal';
+					$order_status[] = 'wc-wps_renewal';
 
 				}
 			}

--- a/package/gateways/wps-paypal/class-wps-subscriptions-payment-wps-paypal-main.php
+++ b/package/gateways/wps-paypal/class-wps-subscriptions-payment-wps-paypal-main.php
@@ -177,7 +177,7 @@ if ( ! class_exists( 'Wps_Subscriptions_Payment_Wps_Paypal_Main' ) ) {
 				$payment_method        = $order->get_payment_method();
 				$wps_sfw_renewal_order = wps_sfw_get_meta_data( $order_id, 'wps_sfw_renewal_order', true );
 				if ( 'wps_paypal' === $payment_method && 'yes' === $wps_sfw_renewal_order ) {
-					$order_status[] = 'wps_renewal';
+					$order_status[] = 'wc-wps_renewal';
 
 				}
 			}


### PR DESCRIPTION
I have not tested these changes so make sure to test it before implementing the changes.

Note that the same issue exists in Subscriptions for WooCommerce Pro plugin so make sure to fix it there as well.

See the issue description at https://github.com/wpswings/subscriptions-for-woocommerce/issues/223 as well as my emails to support.