### PR TITLE
Fix Payment currency is missing for PayPal renewal orders

### DIFF
--- a/package/gateways/paypal/class-wps-sfw-paypal-ipn-handler.php
+++ b/package/gateways/paypal/class-wps-sfw-paypal-ipn-handler.php
@@ -504,7 +504,7 @@ if ( ! class_exists( 'WPS_Sfw_PayPal_IPN_Handler' ) ) {
 					$parent_order = wc_get_order( $parent_order_id );
 					$billing_details = $parent_order->get_address( 'billing' );
 					$shipping_details = $parent_order->get_address( 'shipping' );
-
+					$parent_order_currency = $parent_order->get_currency();
 					$new_status = 'wc-wps_renewal';
 
 					$user_id = $parent_order->get_user_id();
@@ -519,6 +519,7 @@ if ( ! class_exists( 'WPS_Sfw_PayPal_IPN_Handler' ) ) {
 						'customer_id' => $user_id,
 					);
 					$wps_new_order = wc_create_order( $args );
+					$wps_new_order->set_currency( $parent_order_currency );
 
 					$_product = wc_get_product( $product_id );
 


### PR DESCRIPTION
https://github.com/wpswings/subscriptions-for-woocommerce/issues/225