### PR TITLE
Return more than 10 subscriptions in the REST API

### DIFF
--- a/package/rest-api/version1/class-subscriptions-for-woocommerce-api-process.php
+++ b/package/rest-api/version1/class-subscriptions-for-woocommerce-api-process.php
@@ -48,6 +48,7 @@ if ( ! class_exists( 'Subscriptions_For_Woocommerce_Api_Process' ) ) {
 
 			if ( OrderUtil::custom_orders_table_usage_is_enabled() ) {
 				$args = array(
+					'numberposts' => -1,
 					'return' => 'ids',
 					'post_type'   => 'wps_subscriptions',
 					'meta_query' => array(


### PR DESCRIPTION
Currently, when using the REST API, only the first 10 subscriptions will be returned. This PR fixes the issue, with this fix in place all subscriptions will be returned.