### PR TITLE
Hide disabled toggle and checkbox inputs to prevent native display issues

### DIFF
--- a/admin/css/subscriptions-for-woocommerce-admin-global.css
+++ b/admin/css/subscriptions-for-woocommerce-admin-global.css
@@ -2183,6 +2183,18 @@ body.wp-admin.wps-sfw-expert-modal-open {
     width: 1px;
 }
 
+/*
+ * WP core's wp-admin/css/forms.css sets `input[type="checkbox"]:disabled { opacity: 0.7; }`,
+ * which outranks the class-only rule above (extra element + pseudo-class in its selector),
+ * so a disabled toggle/checkbox re-appears as a small native box instead of staying hidden
+ * behind the styled track. Only surfaces on disabled fields (e.g. a locked Pro teaser), which
+ * is why this wasn't caught until one existed.
+ */
+.wps-sfw-check__input:disabled,
+.wps-sfw-toggle__input:disabled {
+    opacity: 0 !important;
+}
+
 .wps-sfw-check__box {
     align-items: center;
     background: #fff;


### PR DESCRIPTION
## Task Link
WPS-7595

## Summary
Adds a disabled, Pro-locked "Enable Gifting Subscription" teaser checkbox to the org plugin's
General Settings (Customer Controls section). Display-only — reuses the existing
`wps_pro_settings` lock/upgrade-modal convention. The real, functional setting is implemented
separately in the Pro plugin.



## Changes Made
- Added "Enable Gifting Subscription" checkbox field (disabled, `wps_pro_settings` class) below
  "Allow Customer To Cancel Subscription" in `admin/class-subscriptions-for-woocommerce-admin.php`
- Fixed disabled checkbox/toggle showing through as a native box instead of staying hidden behind
  the styled track — WP core's `input[type="checkbox"]:disabled { opacity: 0.7; }` was outranking
  the plugin's rule. Added `opacity: 0 !important` for `.wps-sfw-check__input:disabled` and
  `.wps-sfw-toggle__input:disabled` in `admin/css/subscriptions-for-woocommerce-admin-global.css`

## Testing
- Tested locally: No
- Edge cases covered:

## Screenshots / Demo (if applicable)

## Checklist
- [ ] Code reviewed by self
- [ ] No unnecessary code
- [ ] Proper naming conventions
